### PR TITLE
Fix invalid formatter with TTL

### DIFF
--- a/redisdump/redisdump.go
+++ b/redisdump/redisdump.go
@@ -139,7 +139,7 @@ func dumpKeys(client radix.Client, keys []string, withTTL bool, logger *log.Logg
 			}
 			if ttl > 0 {
 				redisCmd = ttlToRedisCmd(key, ttl)
-				logger.Printf(serializer(redisCmd))
+				logger.Print(serializer(redisCmd))
 			}
 		}
 	}


### PR DESCRIPTION
There's an issue when trying to dump/restore some particular keys, preserving the TTL. (This is actually a follow-up of this commit: https://github.com/yannh/redis-dump-go/commit/823cb5cef5557b5c4bb0f8033c9bbf1430929b0d).

Using `Printf` uses a formatter, which can transform the data passed in. For instance, this string `Bourgogne+Franche-Comt%C3%A9+21000` is transformed into `Bourgogne+Franche-Comt%!C(MISSING)3%!A(MISSING)9+21000`.
This is coming from the `fmt` package (as documented here: https://golang.org/pkg/fmt/ - search for "MISSING").

The issue only happens when preserving TTL, as the commit mentioned above fixes the case without TTL. All we need to do is bypass the formatter by calling `Print` instead of `Printf`.