### PR TITLE
fix: nil pointer dereference when selecting database

### DIFF
--- a/acceptance-tests/acceptance.bats
+++ b/acceptance-tests/acceptance.bats
@@ -11,6 +11,11 @@
   [ "$status" -eq 1 ]
 }
 
+@test "Pass when using a non-default db" {
+  run tests/select-db.sh
+  [ "$status" -eq 0 ]
+}
+
 # https://github.com/yannh/redis-dump-go/issues/11
 # https://github.com/yannh/redis-dump-go/issues/18
 @test "Pass when importing a ZSET with 1M entries" {

--- a/acceptance-tests/tests/select-db.sh
+++ b/acceptance-tests/tests/select-db.sh
@@ -1,0 +1,26 @@
+#!/bin/sh -e
+
+export DB=2
+
+echo "-> Filling Redis with Mock Data..."
+redis-cli -h redis -n $DB FLUSHDB
+/generator -output resp -type strings -n 100 | redis-cli -h redis -n $DB --pipe
+DBSIZE=`redis-cli -h redis -n $DB dbsize`
+
+echo "-> Dumping DB..."
+time /redis-dump-go -host redis -n 250 -db $DB -output resp >backup
+
+echo "-> Flushing DB and restoring dump..."
+redis-cli -h redis -n $DB FLUSHDB
+redis-cli -h redis -n $DB --pipe <backup
+NEWDBSIZE=`redis-cli -h redis -n $DB dbsize`
+echo "Redis has $DBSIZE entries"
+
+echo "-> Comparing DB sizes..."
+if [ $DBSIZE -ne $NEWDBSIZE ]; then
+  echo "ERROR - restored DB has $NEWDBSIZE elements, expected $DBSIZE"
+  exit 1
+else
+  echo "OK - $NEWDBSIZE elements"
+  exit 0
+fi

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func realMain() int {
 			return 1
 		}
 	} else {
-		var db *uint8 = nil
+		var db *uint8 = new(uint8)
 		if c.Db != -1 {
 			*db = uint8(c.Db)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,6 +24,19 @@ func TestFromFlags(t *testing.T) {
 			},
 		},
 		{
+			[]string{"-db", "2"},
+			Config{
+				Db:        2,
+				Host:      "127.0.0.1",
+				Port:      6379,
+				Filter:    "*",
+				BatchSize: 1000,
+				NWorkers:  10,
+				WithTTL:   true,
+				Output:    "resp",
+			},
+		},
+		{
 			[]string{"-ttl=false"},
 			Config{
 				Db:        -1,


### PR DESCRIPTION
Prior to this commit the fact of selecting which redis database to dump when making use of the option `-db {redis_db}` would yield a nil pointer de-reference error due to the fact that a nil pointer can not be de-referenced even if it is an assignment expression.