### PR TITLE
Fix Database count limitation

### DIFF
--- a/pkg/redisdump/redisdump.go
+++ b/pkg/redisdump/redisdump.go
@@ -255,9 +255,6 @@ func parseKeyspaceInfo(keyspaceInfo string) ([]uint8, error) {
 		if err != nil {
 			return nil, err
 		}
-		if dbIndex > 16 {
-			return nil, fmt.Errorf("Error parsing INFO keyspace")
-		}
 
 		dbs = append(dbs, uint8(dbIndex))
 	}


### PR DESCRIPTION
Redis can have more than 16 databases.

Fixes #52 